### PR TITLE
Refactor workflow to separate build and deploy jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
-name: Publish Site
+name: Build and Deploy Site
 on: push
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Sources
@@ -26,15 +26,29 @@ jobs:
       env:
         TZ: 'Europe/Prague'
       run: hugo --minify
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: public-site
+        path: public/
+        retention-days: 1
 
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: public-site
+        path: public/
     - name: Install SSH Key
       uses: shimataro/ssh-key-action@v2
       with:
         key: ${{ secrets.DEPLOY_KEY }}
         known_hosts: 'placeholder'
-
     - name: Adding Known Hosts
       run: ssh-keyscan -H ${{ secrets.DEPLOY_HOST_IP }} >> ~/.ssh/known_hosts
-
     - name: Deploy with rsync
       run: rsync -avz --delete ./public/ ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST_IP }}:${{ secrets.DEPLOY_PATH }}


### PR DESCRIPTION
## Summary

- Refactored the GitHub Actions workflow to have separate build and deploy jobs
- Build runs on all pushes (for testing PRs and feature branches)
- Deploy only runs on main branch pushes
- Build artifacts are shared between jobs

## Changes

### Build Job
- Runs on **all pushes** to any branch
- Checks out code, sets up Hugo, builds the site
- Uploads build artifacts for deployment or validation
- This allows PR builds to be tested without deployment

### Deploy Job
- Depends on successful build job
- Only runs when pushing to **main branch**
- Downloads build artifacts from build job
- Performs SSH deployment via rsync

## Benefits

- ✅ PRs and feature branches get build validation without deploying
- ✅ Only main branch changes trigger actual deployment
- ✅ Build step is reused/shared between test and deploy scenarios
- ✅ Faster feedback on build failures for PRs

## Test plan

- [ ] Verify build job runs on PR pushes
- [ ] Verify deploy job is skipped on PR pushes
- [ ] Verify both build and deploy run on main branch pushes
- [ ] Verify deployment succeeds with artifact transfer

🤖 Generated with [Claude Code](https://claude.com/claude-code)