### PR TITLE
Fix Prague tournament date to January 24th

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -70,7 +70,7 @@ The top players of the series play a special finals held at the Pulled Fang tour
 
 <ul>
 <li><strong>Jihlava</strong>: November 29th 2025 (<a href="https://www.vekn.net/event-calendar/event/12654">info</a>)</li>
-<li><strong>Prague</strong>: January 17th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">results</a>)--></li>
+<li><strong>Prague</strong>: January 24th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">results</a>)--></li>
 <li><strong>Lichnov</strong>: February 14th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12073">results</a>)--></li>
 <li><strong>Hradec Králové</strong>: April 18th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12229">results</a>)--></li>
 <li><strong>Olomouc</strong>: May 16th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12358">results</a>)--></li>

--- a/content/_index.md
+++ b/content/_index.md
@@ -63,7 +63,7 @@ Města s aktivní komunitou mají svého místního koordinátora, tzv. prince. 
 
 <ul>
 <li><strong>Jihlava</strong>: 29. listopad 2025 (<a href="https://www.vekn.net/event-calendar/event/12654">info</a>)</li>
-<li><strong>Praha</strong>: 17. leden 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">výsledky</a>)--></li>
+<li><strong>Praha</strong>: 24. leden 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">výsledky</a>)--></li>
 <li><strong>Lichnov</strong>: 14. únor 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12073">výsledky</a>)--></li>
 <li><strong>Hradec Králové</strong>: 18. duben 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12229">výsledky</a>)--></li>
 <li><strong>Olomouc</strong>: 16. květen 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12358">výsledky</a>)--></li>


### PR DESCRIPTION
## Summary
- Updated Road to Pulled Fang #15 Prague tournament date from January 11th to January 24th in both Czech and English versions

## Test plan
- [ ] Verify the date shows as January 24th in the Czech version
- [ ] Verify the date shows as January 24th in the English version

🤖 Generated with [Claude Code](https://claude.com/claude-code)