### PR TITLE
Update RtPF#15 tournament status: mark Jihlava complete, add Prague info link

### DIFF
--- a/content/_index.en.md
+++ b/content/_index.en.md
@@ -69,8 +69,8 @@ To get familiar with the basic rules, watch the following 10-minute video tutori
 The top players of the series play a special finals held at the Pulled Fang tournament:</p>
 
 <ul>
-<li><strong>Jihlava</strong>: November 29th 2025 (<a href="https://www.vekn.net/event-calendar/event/12654">info</a>)</li>
-<li><strong>Prague</strong>: January 24th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">results</a>)--></li>
+<li><s><strong>Jihlava</strong>: November 29th 2025</s> (<a href="https://www.vekn.net/event-calendar/event/12654">results</a>)</li>
+<li><strong>Prague</strong>: January 24th 2026 (<a href="https://www.vekn.net/event-calendar/event/12884">info</a>)</li>
 <li><strong>Lichnov</strong>: February 14th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12073">results</a>)--></li>
 <li><strong>Hradec Králové</strong>: April 18th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12229">results</a>)--></li>
 <li><strong>Olomouc</strong>: May 16th 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12358">results</a>)--></li>

--- a/content/_index.md
+++ b/content/_index.md
@@ -62,8 +62,8 @@ Města s aktivní komunitou mají svého místního koordinátora, tzv. prince. 
 <p>Během roku princové jednotlivých měst organizují jednotlivé turnaje série <strong>"Road to Pulled Fang"</strong>, které dohromady tvoří mini-ligu. Hráči na horních místech hrají na turnaji Pulled Fang speciální finále celé série:</p>
 
 <ul>
-<li><strong>Jihlava</strong>: 29. listopad 2025 (<a href="https://www.vekn.net/event-calendar/event/12654">info</a>)</li>
-<li><strong>Praha</strong>: 24. leden 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/11952">výsledky</a>)--></li>
+<li><s><strong>Jihlava</strong>: 29. listopad 2025</s> (<a href="https://www.vekn.net/event-calendar/event/12654">výsledky</a>)</li>
+<li><strong>Praha</strong>: 24. leden 2026 (<a href="https://www.vekn.net/event-calendar/event/12884">info</a>)</li>
 <li><strong>Lichnov</strong>: 14. únor 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12073">výsledky</a>)--></li>
 <li><strong>Hradec Králové</strong>: 18. duben 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12229">výsledky</a>)--></li>
 <li><strong>Olomouc</strong>: 16. květen 2026<!-- (<a href="https://www.vekn.net/event-calendar/event/12358">výsledky</a>)--></li>


### PR DESCRIPTION
## Summary
- Mark Jihlava tournament (November 29th, 2025) as completed with strikethrough formatting
- Change Jihlava link from "info" to "results"/"výsledky"
- Add Prague tournament info link (https://www.vekn.net/event-calendar/event/12884)

## Test plan
- [ ] Verify Jihlava appears with strikethrough and links to results
- [ ] Verify Prague has active info link to event 12884

🤖 Generated with [Claude Code](https://claude.com/claude-code)